### PR TITLE
Updated to WordPress 4.8 and added dotenv 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "package": {
       "name": "wordpress",
       "type": "webroot",
-      "version": "4.7.3",
+      "version": "4.8",
       "dist": {
         "type": "zip",
-        "url": "https://github.com/WordPress/WordPress/archive/4.7.3.zip"
+        "url": "https://github.com/WordPress/WordPress/archive/4.8.zip"
       },
       "require": {
         "fancyguy/webroot-installer": "1.0.0"
@@ -19,8 +19,9 @@
   }],
   "require": {
     "php": ">=5.3.0",
-    "wordpress": "4.7.3",
-    "fancyguy/webroot-installer": "1.0.0"
+    "wordpress": "4.8",
+    "fancyguy/webroot-installer": "1.0.0",
+    "vlucas/phpdotenv": "^2.4"
   },
   "extra": {
     "webroot-dir": "public/wp",

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -73,7 +73,7 @@ if ( file_exists( dirname( __FILE__ ) . '/local-config.php' ) ) {
 	define("DISALLOW_FILE_MODS", true );
 
 	/** For developers: WordPress debugging mode. */
-	define("WP_DEBUG", false);
+	define("WP_DEBUG", getenv("WP_DEBUG") == "true");
 
 }
 

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -14,6 +14,10 @@
  * @package WordPress
  */
 
+require_once(__DIR__ . '/../vendor/autoload.php');
+(new \Dotenv\Dotenv(__DIR__.'/../'))->load();
+
+
 if ( file_exists( dirname( __FILE__ ) . '/local-config.php' ) ) {
 
 	/** Declare Dev-mode for WordPress */


### PR DESCRIPTION
I updated WordPress to 4.8 and added the dotenv library in order to use getenv on localhost