### PR TITLE
Update to WP 4.8 and added dotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "package": {
       "name": "wordpress",
       "type": "webroot",
-      "version": "4.7.3",
+      "version": "4.8",
       "dist": {
         "type": "zip",
-        "url": "https://github.com/WordPress/WordPress/archive/4.7.3.zip"
+        "url": "https://github.com/WordPress/WordPress/archive/4.8.zip"
       },
       "require": {
         "fancyguy/webroot-installer": "1.0.0"
@@ -19,7 +19,7 @@
   }],
   "require": {
     "php": ">=5.3.0",
-    "wordpress": "4.7.3",
+    "wordpress": "4.8",
     "fancyguy/webroot-installer": "1.0.0"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   "require": {
     "php": ">=5.3.0",
     "wordpress": "4.8",
-    "fancyguy/webroot-installer": "1.0.0"
+    "fancyguy/webroot-installer": "1.0.0",
+    "vlucas/phpdotenv": "^2.4"
   },
   "extra": {
     "webroot-dir": "public/wp",

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -14,6 +14,9 @@
  * @package WordPress
  */
 
+require_once(__DIR__ . '/../vendor/autoload.php');
+(new \Dotenv\Dotenv(__DIR__.'/../'))->load();
+
 if ( file_exists( dirname( __FILE__ ) . '/local-config.php' ) ) {
 
 	/** Declare Dev-mode for WordPress */
@@ -69,7 +72,7 @@ if ( file_exists( dirname( __FILE__ ) . '/local-config.php' ) ) {
 	define("DISALLOW_FILE_MODS", true );
 
 	/** For developers: WordPress debugging mode. */
-	define("WP_DEBUG", false);
+	define("WP_DEBUG", getenv("WP_DEBUG") == "true");
 
 }
 
@@ -101,7 +104,7 @@ define('NONCE_SALT',       'put your unique phrase here');
  *
  * You can have multiple installations in one database if you give each a unique
  * prefix. Only numbers, letters, and underscores please!
- */
+ */	
 $table_prefix  = "wp_";
 
 /**


### PR DESCRIPTION
I updated the Wordpress version to 4.8 and I added the Dotenv package to the repo. This package makes sure that the getenv function is working on localhost as well. 